### PR TITLE
enable automatic updates to nuget dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "dotnet:nuget"
+    directory: "/"
+    update_schedule: "live"
+
+    default_labels:
+      - "kind/dependency"


### PR DESCRIPTION
Similar to https://github.com/nventive/Uno/pull/887

When this merges dependabot will automatically raise PR's to this repo to ensure that `Uno.QuickStart` is kept up to date with Uno itself and any dependencies.

Prompted by https://github.com/nventive/Uno/issues/498